### PR TITLE
Forward 404 responses to SPA

### DIFF
--- a/api/src/main/java/com/hacktheinterview/core/configurations/SwaggerUIConfig.java
+++ b/api/src/main/java/com/hacktheinterview/core/configurations/SwaggerUIConfig.java
@@ -9,6 +9,7 @@ import springfox.documentation.spring.web.plugins.Docket;
 
 @Configuration
 public class SwaggerUIConfig {
+
   @Bean
   public Docket docket() {
     return new Docket(DocumentationType.SWAGGER_2)
@@ -17,4 +18,5 @@ public class SwaggerUIConfig {
       .paths(PathSelectors.any())
       .build();
   }
+
 }

--- a/api/src/main/java/com/hacktheinterview/core/configurations/WebAppConfig.java
+++ b/api/src/main/java/com/hacktheinterview/core/configurations/WebAppConfig.java
@@ -1,0 +1,25 @@
+package com.hacktheinterview.core.configurations;
+
+import org.springframework.boot.web.server.ErrorPage;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebAppConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addViewControllers(ViewControllerRegistry registry) {
+    registry.addViewController("/notFound").setViewName("forward:/index.html");
+  }
+
+  @Bean
+  public WebServerFactoryCustomizer<ConfigurableServletWebServerFactory> containerCustomizer() {
+    return container -> container.addErrorPages(new ErrorPage(HttpStatus.NOT_FOUND, "/notFound"));
+  }
+
+}


### PR DESCRIPTION
__Description__:

All 404 responses from API will be forwarded to index.html.
This wont broke 404 API calls because the forward is performed with an HTTP code 404.
Tested on actual UI and works good.